### PR TITLE
Add ability to set relevant textField properties

### DIFF
--- a/RETableViewManager/Cells/RETableViewTextCell.m
+++ b/RETableViewManager/Cells/RETableViewTextCell.m
@@ -75,6 +75,10 @@
     _textField.returnKeyType = self.item.returnKeyType;
     _textField.enablesReturnKeyAutomatically = self.item.enablesReturnKeyAutomatically;
     _textField.secureTextEntry = self.item.secureTextEntry;
+    _textField.textAlignment = self.item.textFieldTextAlignment;
+    _textField.textColor = self.item.textFieldTextColor;
+    _textField.clearButtonMode = self.item.textFieldClearButtonMode;
+    _textField.clearsOnBeginEditing = self.item.textFieldClearsOnBeginEditing;
 }
 
 - (UIResponder *)responder

--- a/RETableViewManager/Items/RETextItem.h
+++ b/RETableViewManager/Items/RETextItem.h
@@ -32,6 +32,12 @@
 @property (copy, readwrite, nonatomic) NSString *value;
 @property (copy, readwrite, nonatomic) NSString *placeholder;
 
+// TextField
+//
+@property (assign, readwrite, nonatomic) NSTextAlignment textFieldTextAlignment;              // default is NSTextAlignmentLeft
+@property (retain, readwrite, nonatomic) UIColor *textFieldTextColor;                         // default is nil. use opaque black
+@property (assign, readwrite, nonatomic) UITextFieldViewMode textFieldClearButtonMode;        // default is UITextFieldViewModeNever
+@property(assign, readwrite, nonatomic) BOOL textFieldClearsOnBeginEditing;                   // default is NO which moves cursor to location clicked. if YES, all text cleared
 
 // Keyboard
 //


### PR DESCRIPTION
Hi Roman!

Love this library and would like to contribute!

I know that Apple tend to place textFields in the way you do, but I usually like to align all text to the right. I think it looks cleaner. So I added the ability to set textAlignment on the textField. Also added textColor, clearButtonMode and clearsOnBeginEditing which are handy to have in place.

Would be awesome if you could create some tasks for features you have in mind. Maybe I can help you with some feature.

Thanks,

Marthin
