### PR TITLE
Add support to limit characters in RETextItem

### DIFF
--- a/RETableViewManager/Cells/RETableViewTextCell.m
+++ b/RETableViewManager/Cells/RETableViewTextCell.m
@@ -146,4 +146,17 @@
     return YES;
 }
 
+- (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string {
+    if (self.item.onChangeCharacterInRange)
+        self.item.onChangeCharacterInRange(self.item, range, string);
+    
+    if (self.item.charactersLimit) {
+        NSUInteger newLength = textField.text.length + string.length - range.length;
+        return newLength <= 5;
+    }
+    
+    return YES;
+}
+
+
 @end

--- a/RETableViewManager/Items/RETextItem.h
+++ b/RETableViewManager/Items/RETextItem.h
@@ -37,6 +37,9 @@
 @property (assign, readwrite, nonatomic) UITextFieldViewMode clearButtonMode;        // default is UITextFieldViewModeNever
 @property (assign, readwrite, nonatomic) BOOL clearsOnBeginEditing;                   // default is NO which moves cursor to location clicked. if YES, all text cleared
 
+@property (assign, readwrite, nonatomic) NSUInteger charactersLimit;                   // characters limit
+
+
 // Keyboard
 //
 @property (assign, readwrite, nonatomic) UITextAutocapitalizationType autocapitalizationType; // default is UITextAutocapitalizationTypeSentences
@@ -52,6 +55,8 @@
 @property (copy, readwrite, nonatomic) void (^onEndEditing)(RETextItem *item);
 @property (copy, readwrite, nonatomic) void (^onChange)(RETextItem *item);
 @property (copy, readwrite, nonatomic) void (^onReturn)(RETextItem *item);
+@property (copy, readwrite, nonatomic) void (^onChangeCharacterInRange)(RETextItem *item, NSRange range, NSString *replacementString);
+
 
 + (instancetype)itemWithTitle:(NSString *)title value:(NSString *)value;
 + (instancetype)itemWithTitle:(NSString *)title value:(NSString *)value  placeholder:(NSString *)placeholder;

--- a/RETableViewManagerExample/RETableViewManagerExample/Classes/Controllers/ControlsViewController.m
+++ b/RETableViewManagerExample/RETableViewManagerExample/Classes/Controllers/ControlsViewController.m
@@ -29,6 +29,7 @@
 @property (strong, readwrite, nonatomic) REMultipleChoiceItem *multipleChoiceItem;
 @property (strong, readwrite, nonatomic) RELongTextItem *longTextItem;
 @property (strong, readwrite, nonatomic) RECreditCardItem *creditCardItem;
+@property (strong, readwrite, nonatomic) RETextItem *limitTextItem;
 
 @end
 
@@ -164,6 +165,10 @@
     self.longTextItem = [RELongTextItem itemWithValue:nil placeholder:@"Multiline text field"];
     self.longTextItem.cellHeight = 88;
     
+    //Item with limit text
+    self.limitTextItem = [RETextItem itemWithTitle:@"Limit (5)" value:nil placeholder:@"Texts"];
+    self.limitTextItem.charactersLimit = 5;
+    
     [section addItem:self.fullLengthFieldItem];
     [section addItem:self.textItem];
     [section addItem:self.numberItem];
@@ -174,6 +179,7 @@
     [section addItem:self.radioItem];
     [section addItem:self.multipleChoiceItem];
     [section addItem:self.longTextItem];
+    [section addItem:self.limitTextItem];
     
     [section addItem:[MultilineTextItem itemWithTitle:@"Custom item / cell example. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam sem leo, malesuada tempor metus et, elementum pulvinar nibh."]];
     


### PR DESCRIPTION
**Example updated**

In the near future will add additional support to auto set such limits from REValidation NSArray (self.item.validators) like:
1) characters limit
2) decimal || only characters limit
etc...
