### PR TITLE
fixes #135 rowIndex of cells updating when other cells are deleted

### DIFF
--- a/RETableViewManager/RETableViewManager.m
+++ b/RETableViewManager/RETableViewManager.m
@@ -305,12 +305,24 @@
             item.deletionHandlerWithCompletion(item, ^{
                 [section removeItemAtIndex:indexPath.row];
                 [tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
+                
+                for (int i = indexPath.row; i < section.items.count; i++) {
+                    RETableViewItem *afterItem = [[section items] objectAtIndex:i];
+                    RETableViewCell *cell = (RETableViewCell *)[tableView cellForRowAtIndexPath:afterItem.indexPath];
+                    cell.rowIndex--;
+                }
             });
         } else {
             if (item.deletionHandler)
                 item.deletionHandler(item);
             [section removeItemAtIndex:indexPath.row];
             [tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
+            
+            for (int i = indexPath.row; i < section.items.count; i++) {
+                RETableViewItem *afterItem = [[section items] objectAtIndex:i];
+                RETableViewCell *cell = (RETableViewCell *)[tableView cellForRowAtIndexPath:afterItem.indexPath];
+                cell.rowIndex--;
+            }
         }
     }
     


### PR DESCRIPTION
fixes #135

This fixes the bug that I discovered (explained in ticket 135). When a row is deleted, it will iterate through all rows that come after the one deleted, and decrement the rowIndex of the cell
