### PR TITLE
Update RETableViewInlinePickerCell.m

### DIFF
--- a/RETableViewManager/Cells/RETableViewInlinePickerCell.m
+++ b/RETableViewManager/Cells/RETableViewInlinePickerCell.m
@@ -39,6 +39,7 @@
         if ([self.item.pickerItem.options objectAtIndex:idx] && [self.item.pickerItem.value objectAtIndex:idx] > 0)
             [self.pickerView selectRow:[[self.item.pickerItem.options objectAtIndex:idx] indexOfObject:[self.item.pickerItem.value objectAtIndex:idx]] inComponent:idx animated:NO];
     }];
+    [self.pickerView reloadAllComponents];
 }
 
 #pragma mark -


### PR DESCRIPTION
There is weird behaviour when a table has two (or more) **inline** REPickerItem: if you select the first one (the picker view is shown) and then select the second cell, the picker view shows data belonging to the first one.
Forcing the picker view to reload its content whenever the cell is selected, resolves the problem

to reproduce the problem, in the demo project, duplicate the `pickerItem` present in `ControlsViewController.m`, changing its data to easily identify the difference.
