### PR TITLE
Fix textFieldDidChange to fire onChange

### DIFF
--- a/RETableViewManager/Cells/RETableViewNumberCell.m
+++ b/RETableViewManager/Cells/RETableViewNumberCell.m
@@ -83,6 +83,8 @@
 - (void)textFieldDidChange:(REFormattedNumberField *)textField
 {
     self.item.value = textField.unformattedText;
+    if (self.item.onChange)
+        self.item.onChange(self.item);
 }
 - (void)textFieldDidEndEditing:(UITextField *)textField{
     if (self.item.onEndEditing)


### PR DESCRIPTION
Fix a bug where onChange isn't being fired when it should be with RENumberItem/RETableViewNumberCell 
