### PR TITLE
To optimize the picker.

### DIFF
--- a/RETableViewManager/Cells/RETableViewInlinePickerCell.m
+++ b/RETableViewManager/Cells/RETableViewInlinePickerCell.m
@@ -69,6 +69,9 @@
     [self shouldUpdateItemValue];
     if (self.item.pickerItem.onChange)
         self.item.pickerItem.onChange(self.item.pickerItem);
+
+    [pickerView reloadAllComponents];
+    [self shouldUpdateItemValue];
 }
 
 - (void)shouldUpdateItemValue

--- a/RETableViewManager/Cells/RETableViewPickerCell.m
+++ b/RETableViewManager/Cells/RETableViewPickerCell.m
@@ -215,6 +215,10 @@
     [self shouldUpdateItemValue];
     if (self.item.onChange)
         self.item.onChange(self.item);
+
+    [pickerView reloadAllComponents];
+    [self shouldUpdateItemValue];
+
 }
 
 @end


### PR DESCRIPTION
If picker has many rollers,and the datasources of rollers have some relationship. When one of the rollers changed it's value,other rollers should change their datasources and the values on picker.
Such as selecting cities of the province by using picker.

Signed-off-by: Felix yuanlinyue@gmail.com
