### PR TITLE
Removed an unnecessary line of code

### DIFF
--- a/RETableViewManager/RETableViewCell.m
+++ b/RETableViewManager/RETableViewCell.m
@@ -284,7 +284,6 @@
         if (!cell)
             [self.parentTableView scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionTop animated:NO];
         cell = (RETableViewCell *)[self.parentTableView cellForRowAtIndexPath:indexPath];
-        [self.responder resignFirstResponder];
         [cell.responder becomeFirstResponder];
     }
     if (self.item.actionBarNavButtonTapHandler)


### PR DESCRIPTION
When we resignFirstResponder, UIKeyboardWillHideNotification is called. If someone does a custom thing when the keyboard becomes hidden it brings problems. When we remove this line, it won't do any harm.

What do you think?
