### PR TITLE
Fixed picker layout when size changes.

### DIFF
--- a/RETableViewManager/Cells/RETableViewInlineDatePickerCell.m
+++ b/RETableViewManager/Cells/RETableViewInlineDatePickerCell.m
@@ -7,6 +7,7 @@
 //
 
 #import "RETableViewInlineDatePickerCell.h"
+#import "RETableViewManager.h"
 #import "REDateTimeItem.h"
 
 @interface RETableViewInlineDatePickerCell ()
@@ -42,6 +43,15 @@
     self.datePicker.minimumDate = self.item.dateTimeItem.minimumDate;
     self.datePicker.maximumDate = self.item.dateTimeItem.maximumDate;
     self.datePicker.minuteInterval = self.item.dateTimeItem.minuteInterval;
+}
+
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+    self.datePicker.frame = self.bounds;
+    
+    if ([self.tableViewManager.delegate respondsToSelector:@selector(tableView:willLayoutCellSubviews:forRowAtIndexPath:)])
+        [self.tableViewManager.delegate tableView:self.tableViewManager.tableView willLayoutCellSubviews:self forRowAtIndexPath:[self.tableViewManager.tableView indexPathForCell:self]];
 }
 
 #pragma mark -

--- a/RETableViewManager/Cells/RETableViewInlinePickerCell.m
+++ b/RETableViewManager/Cells/RETableViewInlinePickerCell.m
@@ -7,6 +7,7 @@
 //
 
 #import "RETableViewInlinePickerCell.h"
+#import "RETableViewManager.h"
 #import "REPickerItem.h"
 
 @interface RETableViewInlinePickerCell ()
@@ -40,6 +41,15 @@
             [self.pickerView selectRow:[[self.item.pickerItem.options objectAtIndex:idx] indexOfObject:[self.item.pickerItem.value objectAtIndex:idx]] inComponent:idx animated:NO];
     }];
     [self.pickerView reloadAllComponents];
+}
+
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+    self.pickerView.frame = self.bounds;
+    
+    if ([self.tableViewManager.delegate respondsToSelector:@selector(tableView:willLayoutCellSubviews:forRowAtIndexPath:)])
+        [self.tableViewManager.delegate tableView:self.tableViewManager.tableView willLayoutCellSubviews:self forRowAtIndexPath:[self.tableViewManager.tableView indexPathForCell:self]];
 }
 
 #pragma mark -


### PR DESCRIPTION
If the view rotates after an inline picker cell has been created then the picker will always keep the original size.

![picker](https://cloud.githubusercontent.com/assets/1442307/2965453/f5d29806-daf6-11e3-9674-6cae69aa6e7f.png)

Fixed by changing the size of the picker in layoutSubviews.
