### PR TITLE
Fix possible NSRangeException in -tableView:canEditRowAtIndexPath:

### DIFF
--- a/RETableViewManager/RETableViewManager.m
+++ b/RETableViewManager/RETableViewManager.m
@@ -287,12 +287,16 @@
 
 - (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    RETableViewSection *section = [self.mutableSections objectAtIndex:indexPath.section];
-    RETableViewItem *item = [section.items objectAtIndex:indexPath.row];
-    if ([item isKindOfClass:[RETableViewItem class]]) {
-        return item.editingStyle != UITableViewCellEditingStyleNone || item.moveHandler;
+    if (indexPath.section < [self.mutableSections count]) {
+        RETableViewSection *section = [self.mutableSections objectAtIndex:indexPath.section];
+        if (indexPath.row < [section.items count]) {
+            RETableViewItem *item = [section.items objectAtIndex:indexPath.row];
+            if ([item isKindOfClass:[RETableViewItem class]]) {
+                return item.editingStyle != UITableViewCellEditingStyleNone || item.moveHandler;
+            }
+        }
     }
-    
+
     return NO;
 }
 


### PR DESCRIPTION
On iOS 8 `NSRangeException` was being thrown after calling `-removeItem:` and then `-reloadSectionWithAnimation:`.
The fix adds checks if section and row indices are within bounds.
