### PR TITLE
Update RETableViewBoolCell.m

### DIFF
--- a/RETableViewManager/Cells/RETableViewBoolCell.m
+++ b/RETableViewManager/Cells/RETableViewBoolCell.m
@@ -82,7 +82,8 @@
 - (void)layoutSubviews
 {
     [super layoutSubviews];
-    self.textLabel.frame = CGRectMake(self.textLabel.frame.origin.x, self.textLabel.frame.origin.y, self.textLabel.frame.size.width - self.switchView.frame.size.width - self.section.style.contentViewMargin - 10.0, self.textLabel.frame.size.height);
+    if (self.textLabel.frame.origin.x + self.textLabel.frame.size.width >= self.switchView.frame.origin.x)
+        self.textLabel.frame = CGRectMake(self.textLabel.frame.origin.x, self.textLabel.frame.origin.y, self.textLabel.frame.size.width - self.switchView.frame.size.width - self.section.style.contentViewMargin - 10.0, self.textLabel.frame.size.height);
     self.textLabel.autoresizingMask = UIViewAutoresizingFlexibleWidth;
     if ([self.tableViewManager.delegate respondsToSelector:@selector(tableView:willLayoutCellSubviews:forRowAtIndexPath:)])
         [self.tableViewManager.delegate tableView:self.tableViewManager.tableView willLayoutCellSubviews:self forRowAtIndexPath:[self.tableViewManager.tableView indexPathForCell:self]];


### PR DESCRIPTION
In iOS 8, self.textLabel have the size of text and not the width of cell. With current code, text are truncated. There are maybe a better way to handle this (autolayout ?)
