### PR TITLE
fixed invalid  next responder check if not found

### DIFF
--- a/RETableViewManager/RETableViewCell.m
+++ b/RETableViewManager/RETableViewCell.m
@@ -106,6 +106,8 @@
         self.textLabel.backgroundColor = [UIColor clearColor];
         self.accessoryType = item.accessoryType;
         self.accessoryView = item.accessoryView;
+        self.editingAccessoryType = item.editingAccessoryType;
+        self.editingAccessoryView = item.editingAccessoryView;
         self.textLabel.textAlignment = item.textAlignment;
         if (self.selectionStyle != UITableViewCellSelectionStyleNone)
             self.selectionStyle = item.selectionStyle;

--- a/RETableViewManager/RETableViewCell.m
+++ b/RETableViewManager/RETableViewCell.m
@@ -250,7 +250,7 @@
 - (NSIndexPath *)indexPathForNextResponderInSectionIndex:(NSUInteger)sectionIndex
 {
     RETableViewSection *section = [self.tableViewManager.sections objectAtIndex:sectionIndex];
-    NSUInteger indexInSection =  [section isEqual:self.section] ? [section.items indexOfObject:self.item] : -1;
+    NSUInteger indexInSection =  [section isEqual:self.section] ? [section.items indexOfObject:self.item] : -2 - section.items.count;
     for (NSInteger i = indexInSection + 1; i < section.items.count; i++) {
         RETableViewItem *item = [section.items objectAtIndex:i];
         if ([item isKindOfClass:[RETableViewItem class]]) {

--- a/RETableViewManager/RETableViewItem.h
+++ b/RETableViewManager/RETableViewItem.h
@@ -40,11 +40,14 @@
 @property (assign, readwrite, nonatomic) UITableViewCellStyle style;
 @property (assign, readwrite, nonatomic) UITableViewCellSelectionStyle selectionStyle;
 @property (assign, readwrite, nonatomic) UITableViewCellAccessoryType accessoryType;
+@property (assign, readwrite, nonatomic) UITableViewCellAccessoryType editingAccessoryType;
 @property (assign, readwrite, nonatomic) UITableViewCellEditingStyle editingStyle;
 @property (strong, readwrite, nonatomic) UIView *accessoryView;
+@property (strong, readwrite, nonatomic) UIView *editingAccessoryView;
 @property (assign, readwrite, nonatomic) BOOL enabled;
 @property (copy, readwrite, nonatomic) void (^selectionHandler)(id item);
 @property (copy, readwrite, nonatomic) void (^accessoryButtonTapHandler)(id item);
+@property (copy, readwrite, nonatomic) void (^editingAccessoryButtonTapHandler)(id item);
 @property (copy, readwrite, nonatomic) void (^insertionHandler)(id item);
 @property (copy, readwrite, nonatomic) void (^deletionHandler)(id item);
 @property (copy, readwrite, nonatomic) void (^deletionHandlerWithCompletion)(id item, void (^)(void));

--- a/RETableViewManager/RETableViewManager.m
+++ b/RETableViewManager/RETableViewManager.m
@@ -563,10 +563,21 @@
 {
     RETableViewSection *section = [self.mutableSections objectAtIndex:indexPath.section];
     id item = [section.items objectAtIndex:indexPath.row];
-    if ([item respondsToSelector:@selector(setAccessoryButtonTapHandler:)]) {
-        RETableViewItem *actionItem = (RETableViewItem *)item;
-        if (actionItem.accessoryButtonTapHandler)
-            actionItem.accessoryButtonTapHandler(item);
+    
+    if (self.tableView.editing) {
+        
+        if ([item respondsToSelector:@selector(setEditingAccessoryButtonTapHandler:)]) {
+            RETableViewItem *actionItem = (RETableViewItem *)item;
+            if (actionItem.editingAccessoryButtonTapHandler)
+                actionItem.editingAccessoryButtonTapHandler(item);
+        }
+        
+    } else {
+        if ([item respondsToSelector:@selector(setAccessoryButtonTapHandler:)]) {
+            RETableViewItem *actionItem = (RETableViewItem *)item;
+            if (actionItem.accessoryButtonTapHandler)
+                actionItem.accessoryButtonTapHandler(item);
+        }
     }
     
     // Forward to UITableView delegate


### PR DESCRIPTION
A bug exists when indexPathForNextResponderInSectionIndex: on RETableViewCell.m if the sections do not match. If not, the value is set to -1. The for loop below automaticall adds 1 to the unsigned -1, which makes it 0. Thus, the for loop condition was met when it shouldn't have been.

By setting it to -2 then subtracting the number of items in the section, the for loop conidition will never be met when the section is not equal.
