### PR TITLE
Make RETableViewManager.delegate a weak reference (fixes #237)

### DIFF
--- a/RETableViewManager/RETableViewManager.h
+++ b/RETableViewManager/RETableViewManager.h
@@ -105,7 +105,7 @@
 /**
  The object that acts as the delegate of the receiving table view.
  */
-@property (assign, readwrite, nonatomic) id<RETableViewManagerDelegate> delegate;
+@property (weak, readwrite, nonatomic) id<RETableViewManagerDelegate> delegate;
 
 ///-----------------------------
 /// @name Managing Custom Cells


### PR DESCRIPTION
Is there a reason for the RETableViewManager delegate to be `assign` instead of `weak`? I've noticed that other parts of this excellent pod already use `weak` for delegates. This just reduces the chances of being bitten by a dangling pointer.