### PR TITLE
Cocoapods use_frameworks resource fix

### DIFF
--- a/RETableViewManager/Cells/RETableViewCreditCardCell.m
+++ b/RETableViewManager/Cells/RETableViewCreditCardCell.m
@@ -27,6 +27,7 @@
 #import "RETableViewCreditCardCell.h"
 #import "RETableViewManager.h"
 #import "NSString+RETableViewManagerAdditions.h"
+#import "NSBundle+RETableViewManager.h"
 
 @interface RETableViewCreditCardCell ()
 
@@ -52,22 +53,22 @@
 @synthesize item = _item;
 
 static NSString * const creditCardTypeImage[] = {
-        [RECreditCardTypeUnknown] = @"RETableViewManager.bundle/Card_Stack",
-        [RECreditCardTypeVisa] = @"RETableViewManager.bundle/Card_Visa",
-        [RECreditCardTypeMasterCard] = @"RETableViewManager.bundle/Card_Mastercard",
-        [RECreditCardTypeDiscover] = @"RETableViewManager.bundle/Card_Discover",
-        [RECreditCardTypeAmex] = @"RETableViewManager.bundle/Card_Amex"
+        [RECreditCardTypeUnknown] = @"Card_Stack",
+        [RECreditCardTypeVisa] = @"Card_Visa",
+        [RECreditCardTypeMasterCard] = @"Card_Mastercard",
+        [RECreditCardTypeDiscover] = @"Card_Discover",
+        [RECreditCardTypeAmex] = @"Card_Amex"
 };
 
 static inline BOOL RECreditCardExpired(NSString *creditCardExpirationDate)
 {
     if ([creditCardExpirationDate isEqualToString:@""])
         return NO;
-    
+
     NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
     dateFormatter.dateFormat = @"MM/yy";
     NSDate *cardDate = [dateFormatter dateFromString:creditCardExpirationDate];
-    
+
     NSDateComponents *dateComponents = [[NSCalendar currentCalendar] components:(NSYearCalendarUnit | NSMonthCalendarUnit | NSDayCalendarUnit) fromDate:[NSDate date]];
     dateComponents.day = 1;
     NSDate *firstDayOfMonthDate = [[NSCalendar currentCalendar] dateFromComponents:dateComponents];
@@ -116,28 +117,28 @@ static inline RECreditCardType RECreditCardTypeFromNumber(NSString *creditCardNu
 
     self.selectionStyle = UITableViewCellSelectionStyleNone;
     self.textLabel.backgroundColor = [UIColor clearColor];
-    
+
     self.creditCardImageViewContainer = [[UIView alloc] init];
     [self.contentView addSubview:self.creditCardImageViewContainer];
-    
+
     self.creditCardStackImageView = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, 32, 32)];
-    self.creditCardStackImageView.image = [UIImage imageNamed:creditCardTypeImage[RECreditCardTypeUnknown]];
+    self.creditCardStackImageView.image = [UIImage imageNamed:creditCardTypeImage[RECreditCardTypeUnknown] inBundle:[NSBundle RETableViewManagerBundle] compatibleWithTraitCollection:nil];
     self.creditCardStackImageView.tag = 0;
     self.currentImageView = self.creditCardStackImageView;
     [self.creditCardImageViewContainer addSubview:self.creditCardStackImageView];
-    
+
     self.creditCardImageView = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, 32, 32)];
-    self.creditCardImageView.image = [UIImage imageNamed:creditCardTypeImage[RECreditCardTypeVisa]];
+    self.creditCardImageView.image = [UIImage imageNamed:creditCardTypeImage[RECreditCardTypeVisa] inBundle:[NSBundle RETableViewManagerBundle] compatibleWithTraitCollection:nil];
     self.creditCardImageView.tag = 1;
-    
+
     self.creditCardBackImageView = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, 32, 32)];
-    self.creditCardBackImageView.image = [UIImage imageNamed:@"RETableViewManager.bundle/Card_Back"];
+    self.creditCardBackImageView.image = [UIImage imageNamed:@"Card_Back" inBundle:[NSBundle RETableViewManagerBundle] compatibleWithTraitCollection:nil];
     self.creditCardBackImageView.tag = 2;
-    
+
     self.wrapperView = [[UIView alloc] initWithFrame:CGRectMake(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone ? 60 : 60 + self.textFieldPositionOffset.width, self.textFieldPositionOffset.height, self.frame.size.width - 70, self.frame.size.height)];
     self.wrapperView.clipsToBounds = YES;
     [self.contentView addSubview:self.wrapperView];
-    
+
     self.creditCardField = [[REFormattedNumberField alloc] initWithFrame:CGRectMake(0, 0, 216, self.frame.size.height - self.textFieldPositionOffset.height)];
     self.creditCardField.tag = 0;
     self.creditCardField.contentVerticalAlignment = UIControlContentVerticalAlignmentCenter;
@@ -147,8 +148,8 @@ static inline RECreditCardType RECreditCardTypeFromNumber(NSString *creditCardNu
     self.creditCardField.format = @"XXXX XXXX XXXX XXXX";
     [self.creditCardField addTarget:self action:@selector(textFieldDidChange:) forControlEvents:UIControlEventEditingChanged];
     [self.wrapperView addSubview:self.creditCardField];
-    
-    
+
+
     self.expirationDateField = [[REFormattedNumberField alloc] initWithFrame:CGRectMake(320, 0, 80, self.frame.size.height)];
     self.expirationDateField.tag = 1;
     self.expirationDateField.contentVerticalAlignment = UIControlContentVerticalAlignmentCenter;
@@ -170,7 +171,7 @@ static inline RECreditCardType RECreditCardTypeFromNumber(NSString *creditCardNu
     [self.wrapperView addSubview:self.cvvField];
 
     self.ribbonExpired = [[UIImageView alloc] init];
-    
+
     self.enabled = self.item.enabled;
 
     [self.contentView addSubview:self.ribbonExpired];
@@ -179,15 +180,15 @@ static inline RECreditCardType RECreditCardTypeFromNumber(NSString *creditCardNu
 - (void)cellWillAppear
 {
     CGFloat cellOffset = 10.0;
-    
+
     if (self.section.style.contentViewMargin <= 0)
         cellOffset += 5.0;
     self.creditCardImageViewContainer.frame = CGRectMake(cellOffset, 5, 32, 32);
-    
+
     self.textLabel.text = self.item.title;
-    
+
     self.item.creditCardType = RECreditCardTypeFromNumber(self.item.number);
-    
+
     if (self.item.creditCardType != RECreditCardTypeAmex && self.item.number.length < 16) {
         self.isNumberEditingMode = YES;
     } else if (self.item.creditCardType == RECreditCardTypeAmex && self.item.number.length < 15) {
@@ -199,21 +200,21 @@ static inline RECreditCardType RECreditCardTypeFromNumber(NSString *creditCardNu
     self.creditCardField.text = [self.item.number re_stringWithNumberFormat:self.creditCardField.format];
     self.creditCardField.font = [UIFont systemFontOfSize:17];
     self.creditCardField.keyboardAppearance = self.item.keyboardAppearance;
-    
+
     self.expirationDateField.text = self.item.expirationDate;
     self.expirationDateField.font = [UIFont systemFontOfSize:17];
     self.expirationDateField.keyboardAppearance = self.item.keyboardAppearance;
-    
+
     self.cvvField.text = self.item.cvv;
     self.cvvField.font = [UIFont systemFontOfSize:17];
     self.cvvField.keyboardAppearance = self.item.keyboardAppearance;
     self.cvvField.hidden = !self.item.cvvRequired;
-    
+
     self.ribbonExpired.image = self.item.expiredRibbonImage;
     self.ribbonExpired.hidden = !RECreditCardExpired(self.expirationDateField.text);
 
     if (self.item.creditCardType != RECreditCardTypeUnknown ) {
-        self.creditCardImageView.image = [UIImage imageNamed:creditCardTypeImage[self.item.creditCardType]];
+        self.creditCardImageView.image = [UIImage imageNamed:creditCardTypeImage[self.item.creditCardType] inBundle:[NSBundle RETableViewManagerBundle] compatibleWithTraitCollection:nil];
         [UIView transitionFromView:self.creditCardStackImageView toView:self.creditCardImageView duration:0.4 options:UIViewAnimationOptionTransitionFlipFromLeft completion:nil];
         self.currentImageView = self.creditCardImageView;
     }
@@ -231,7 +232,7 @@ static inline RECreditCardType RECreditCardTypeFromNumber(NSString *creditCardNu
     frame.size.width += UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone ? 30 : 50;
     frame.size.height = self.contentView.frame.size.height;
     self.creditCardField.frame = frame;
-    
+
     frame = self.expirationDateField.frame;
     frame.size.width += UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone ? 30 : 50;
     frame.size.height = self.contentView.frame.size.height;
@@ -257,7 +258,7 @@ static inline RECreditCardType RECreditCardTypeFromNumber(NSString *creditCardNu
         self.expirationDateField.frame = CGRectMake(CGRectGetMaxX(self.creditCardField.frame), self.expirationDateField.frame.origin.y, self.expirationDateField.frame.size.width, self.expirationDateField.frame.size.height);
         self.cvvField.frame = CGRectMake(CGRectGetMaxX(self.expirationDateField.frame), self.cvvField.frame.origin.y, self.cvvField.frame.size.width, self.cvvField.frame.size.height);
     }
-    
+
     if ([self.tableViewManager.delegate respondsToSelector:@selector(tableView:willLayoutCellSubviews:forRowAtIndexPath:)])
         [self.tableViewManager.delegate tableView:self.tableViewManager.tableView willLayoutCellSubviews:self forRowAtIndexPath:[self.tableViewManager.tableView indexPathForCell:self]];
 }
@@ -290,17 +291,17 @@ static inline RECreditCardType RECreditCardTypeFromNumber(NSString *creditCardNu
     if (_item != nil) {
         [_item removeObserver:self forKeyPath:@"enabled"];
     }
-    
+
     _item = item;
-    
+
     [_item addObserver:self forKeyPath:@"enabled" options:NSKeyValueObservingOptionNew context:NULL];
 }
 
 - (void)setEnabled:(BOOL)enabled {
     _enabled = enabled;
-    
+
     self.userInteractionEnabled = _enabled;
-    
+
     self.textLabel.enabled = _enabled;
     self.creditCardField.enabled = _enabled;
     self.expirationDateField.enabled = _enabled;
@@ -311,7 +312,7 @@ static inline RECreditCardType RECreditCardTypeFromNumber(NSString *creditCardNu
 {
     if ([object isKindOfClass:[REBoolItem class]] && [keyPath isEqualToString:@"enabled"]) {
         BOOL newValue = [[change objectForKey: NSKeyValueChangeNewKey] boolValue];
-        
+
         self.enabled = newValue;
     }
 }
@@ -323,12 +324,12 @@ static inline RECreditCardType RECreditCardTypeFromNumber(NSString *creditCardNu
 {
     if (textField.tag == 0) {
         self.item.number = textField.text;
-        
+
         RECreditCardType cardType = RECreditCardTypeFromNumber(self.item.number);
         self.item.creditCardType = cardType;
-        
+
         if (cardType != RECreditCardTypeUnknown) {
-            self.creditCardImageView.image = [UIImage imageNamed:creditCardTypeImage[cardType]];
+            self.creditCardImageView.image = [UIImage imageNamed:creditCardTypeImage[cardType] inBundle:[NSBundle RETableViewManagerBundle] compatibleWithTraitCollection:nil];
             [UIView transitionFromView:self.creditCardStackImageView toView:self.creditCardImageView duration:0.4 options:UIViewAnimationOptionTransitionFlipFromLeft completion:nil];
             self.currentImageView = self.creditCardImageView;
         } else {
@@ -337,9 +338,9 @@ static inline RECreditCardType RECreditCardTypeFromNumber(NSString *creditCardNu
                 self.currentImageView = self.creditCardStackImageView;
             }
         }
-        
+
         BOOL isAmex = cardType == RECreditCardTypeAmex;
-        
+
         if (textField.text.length == (isAmex ? 18 : 19) ) {
             [self.expirationDateField becomeFirstResponder];
             [UIView animateWithDuration:0.1 animations:^{
@@ -351,7 +352,7 @@ static inline RECreditCardType RECreditCardTypeFromNumber(NSString *creditCardNu
                 self.cvvField.frame = CGRectMake(CGRectGetMaxX(self.expirationDateField.frame), self.cvvField.frame.origin.y, self.cvvField.frame.size.width, self.cvvField.frame.size.height);
             }];
         }
-        
+
         if (textField.text.length == (isAmex ? 17 : 18) ) {
             [UIView animateWithDuration:0.1 animations:^{
                 self.isNumberEditingMode = YES;
@@ -361,19 +362,19 @@ static inline RECreditCardType RECreditCardTypeFromNumber(NSString *creditCardNu
             }];
         }
     }
-    
+
     if (textField.tag == 1) {
         self.item.expirationDate = textField.text;
-        
+
         if(textField.text.length == 5 && self.item.cvvRequired) {
             [self.cvvField becomeFirstResponder];
         }
     }
-    
+
     if (textField.tag == 2) self.item.cvv = textField.text;
 }
 
-#pragma mark - 
+#pragma mark -
 #pragma mark UITextFieldDelegate
 
 - (BOOL)textFieldShouldBeginEditing:(UITextField *)textField
@@ -385,14 +386,14 @@ static inline RECreditCardType RECreditCardTypeFromNumber(NSString *creditCardNu
     if (textField.tag == 2) {
         [UIView transitionFromView:self.currentImageView toView:self.creditCardBackImageView duration:0.4 options:UIViewAnimationOptionTransitionFlipFromLeft completion:nil];
     }
-    
+
     return YES;
 }
 
 - (BOOL)textFieldShouldEndEditing:(UITextField *)textField
 {
     [self performSelector:@selector(flipCreditCardImageViewBack:) withObject:textField afterDelay:0.1];
-    
+
     if (textField == self.expirationDateField) {
         self.ribbonExpired.hidden = !RECreditCardExpired(self.expirationDateField.text);
     }

--- a/RETableViewManager/Cells/RETableViewCreditCardCell.m
+++ b/RETableViewManager/Cells/RETableViewCreditCardCell.m
@@ -64,11 +64,11 @@ static inline BOOL RECreditCardExpired(NSString *creditCardExpirationDate)
 {
     if ([creditCardExpirationDate isEqualToString:@""])
         return NO;
-
+    
     NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
     dateFormatter.dateFormat = @"MM/yy";
     NSDate *cardDate = [dateFormatter dateFromString:creditCardExpirationDate];
-
+    
     NSDateComponents *dateComponents = [[NSCalendar currentCalendar] components:(NSYearCalendarUnit | NSMonthCalendarUnit | NSDayCalendarUnit) fromDate:[NSDate date]];
     dateComponents.day = 1;
     NSDate *firstDayOfMonthDate = [[NSCalendar currentCalendar] dateFromComponents:dateComponents];
@@ -117,28 +117,28 @@ static inline RECreditCardType RECreditCardTypeFromNumber(NSString *creditCardNu
 
     self.selectionStyle = UITableViewCellSelectionStyleNone;
     self.textLabel.backgroundColor = [UIColor clearColor];
-
+    
     self.creditCardImageViewContainer = [[UIView alloc] init];
     [self.contentView addSubview:self.creditCardImageViewContainer];
-
+    
     self.creditCardStackImageView = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, 32, 32)];
     self.creditCardStackImageView.image = [UIImage imageNamed:creditCardTypeImage[RECreditCardTypeUnknown] inBundle:[NSBundle RETableViewManagerBundle] compatibleWithTraitCollection:nil];
     self.creditCardStackImageView.tag = 0;
     self.currentImageView = self.creditCardStackImageView;
     [self.creditCardImageViewContainer addSubview:self.creditCardStackImageView];
-
+    
     self.creditCardImageView = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, 32, 32)];
     self.creditCardImageView.image = [UIImage imageNamed:creditCardTypeImage[RECreditCardTypeVisa] inBundle:[NSBundle RETableViewManagerBundle] compatibleWithTraitCollection:nil];
     self.creditCardImageView.tag = 1;
-
+    
     self.creditCardBackImageView = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, 32, 32)];
     self.creditCardBackImageView.image = [UIImage imageNamed:@"Card_Back" inBundle:[NSBundle RETableViewManagerBundle] compatibleWithTraitCollection:nil];
     self.creditCardBackImageView.tag = 2;
-
+    
     self.wrapperView = [[UIView alloc] initWithFrame:CGRectMake(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone ? 60 : 60 + self.textFieldPositionOffset.width, self.textFieldPositionOffset.height, self.frame.size.width - 70, self.frame.size.height)];
     self.wrapperView.clipsToBounds = YES;
     [self.contentView addSubview:self.wrapperView];
-
+    
     self.creditCardField = [[REFormattedNumberField alloc] initWithFrame:CGRectMake(0, 0, 216, self.frame.size.height - self.textFieldPositionOffset.height)];
     self.creditCardField.tag = 0;
     self.creditCardField.contentVerticalAlignment = UIControlContentVerticalAlignmentCenter;
@@ -148,8 +148,8 @@ static inline RECreditCardType RECreditCardTypeFromNumber(NSString *creditCardNu
     self.creditCardField.format = @"XXXX XXXX XXXX XXXX";
     [self.creditCardField addTarget:self action:@selector(textFieldDidChange:) forControlEvents:UIControlEventEditingChanged];
     [self.wrapperView addSubview:self.creditCardField];
-
-
+    
+    
     self.expirationDateField = [[REFormattedNumberField alloc] initWithFrame:CGRectMake(320, 0, 80, self.frame.size.height)];
     self.expirationDateField.tag = 1;
     self.expirationDateField.contentVerticalAlignment = UIControlContentVerticalAlignmentCenter;
@@ -171,7 +171,7 @@ static inline RECreditCardType RECreditCardTypeFromNumber(NSString *creditCardNu
     [self.wrapperView addSubview:self.cvvField];
 
     self.ribbonExpired = [[UIImageView alloc] init];
-
+    
     self.enabled = self.item.enabled;
 
     [self.contentView addSubview:self.ribbonExpired];
@@ -180,15 +180,15 @@ static inline RECreditCardType RECreditCardTypeFromNumber(NSString *creditCardNu
 - (void)cellWillAppear
 {
     CGFloat cellOffset = 10.0;
-
+    
     if (self.section.style.contentViewMargin <= 0)
         cellOffset += 5.0;
     self.creditCardImageViewContainer.frame = CGRectMake(cellOffset, 5, 32, 32);
-
+    
     self.textLabel.text = self.item.title;
-
+    
     self.item.creditCardType = RECreditCardTypeFromNumber(self.item.number);
-
+    
     if (self.item.creditCardType != RECreditCardTypeAmex && self.item.number.length < 16) {
         self.isNumberEditingMode = YES;
     } else if (self.item.creditCardType == RECreditCardTypeAmex && self.item.number.length < 15) {
@@ -200,16 +200,16 @@ static inline RECreditCardType RECreditCardTypeFromNumber(NSString *creditCardNu
     self.creditCardField.text = [self.item.number re_stringWithNumberFormat:self.creditCardField.format];
     self.creditCardField.font = [UIFont systemFontOfSize:17];
     self.creditCardField.keyboardAppearance = self.item.keyboardAppearance;
-
+    
     self.expirationDateField.text = self.item.expirationDate;
     self.expirationDateField.font = [UIFont systemFontOfSize:17];
     self.expirationDateField.keyboardAppearance = self.item.keyboardAppearance;
-
+    
     self.cvvField.text = self.item.cvv;
     self.cvvField.font = [UIFont systemFontOfSize:17];
     self.cvvField.keyboardAppearance = self.item.keyboardAppearance;
     self.cvvField.hidden = !self.item.cvvRequired;
-
+    
     self.ribbonExpired.image = self.item.expiredRibbonImage;
     self.ribbonExpired.hidden = !RECreditCardExpired(self.expirationDateField.text);
 
@@ -232,7 +232,7 @@ static inline RECreditCardType RECreditCardTypeFromNumber(NSString *creditCardNu
     frame.size.width += UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone ? 30 : 50;
     frame.size.height = self.contentView.frame.size.height;
     self.creditCardField.frame = frame;
-
+    
     frame = self.expirationDateField.frame;
     frame.size.width += UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone ? 30 : 50;
     frame.size.height = self.contentView.frame.size.height;
@@ -258,7 +258,7 @@ static inline RECreditCardType RECreditCardTypeFromNumber(NSString *creditCardNu
         self.expirationDateField.frame = CGRectMake(CGRectGetMaxX(self.creditCardField.frame), self.expirationDateField.frame.origin.y, self.expirationDateField.frame.size.width, self.expirationDateField.frame.size.height);
         self.cvvField.frame = CGRectMake(CGRectGetMaxX(self.expirationDateField.frame), self.cvvField.frame.origin.y, self.cvvField.frame.size.width, self.cvvField.frame.size.height);
     }
-
+    
     if ([self.tableViewManager.delegate respondsToSelector:@selector(tableView:willLayoutCellSubviews:forRowAtIndexPath:)])
         [self.tableViewManager.delegate tableView:self.tableViewManager.tableView willLayoutCellSubviews:self forRowAtIndexPath:[self.tableViewManager.tableView indexPathForCell:self]];
 }
@@ -291,17 +291,17 @@ static inline RECreditCardType RECreditCardTypeFromNumber(NSString *creditCardNu
     if (_item != nil) {
         [_item removeObserver:self forKeyPath:@"enabled"];
     }
-
+    
     _item = item;
-
+    
     [_item addObserver:self forKeyPath:@"enabled" options:NSKeyValueObservingOptionNew context:NULL];
 }
 
 - (void)setEnabled:(BOOL)enabled {
     _enabled = enabled;
-
+    
     self.userInteractionEnabled = _enabled;
-
+    
     self.textLabel.enabled = _enabled;
     self.creditCardField.enabled = _enabled;
     self.expirationDateField.enabled = _enabled;
@@ -312,7 +312,7 @@ static inline RECreditCardType RECreditCardTypeFromNumber(NSString *creditCardNu
 {
     if ([object isKindOfClass:[REBoolItem class]] && [keyPath isEqualToString:@"enabled"]) {
         BOOL newValue = [[change objectForKey: NSKeyValueChangeNewKey] boolValue];
-
+        
         self.enabled = newValue;
     }
 }
@@ -324,10 +324,10 @@ static inline RECreditCardType RECreditCardTypeFromNumber(NSString *creditCardNu
 {
     if (textField.tag == 0) {
         self.item.number = textField.text;
-
+        
         RECreditCardType cardType = RECreditCardTypeFromNumber(self.item.number);
         self.item.creditCardType = cardType;
-
+        
         if (cardType != RECreditCardTypeUnknown) {
             self.creditCardImageView.image = [UIImage imageNamed:creditCardTypeImage[cardType] inBundle:[NSBundle RETableViewManagerBundle] compatibleWithTraitCollection:nil];
             [UIView transitionFromView:self.creditCardStackImageView toView:self.creditCardImageView duration:0.4 options:UIViewAnimationOptionTransitionFlipFromLeft completion:nil];
@@ -338,9 +338,9 @@ static inline RECreditCardType RECreditCardTypeFromNumber(NSString *creditCardNu
                 self.currentImageView = self.creditCardStackImageView;
             }
         }
-
+        
         BOOL isAmex = cardType == RECreditCardTypeAmex;
-
+        
         if (textField.text.length == (isAmex ? 18 : 19) ) {
             [self.expirationDateField becomeFirstResponder];
             [UIView animateWithDuration:0.1 animations:^{
@@ -352,7 +352,7 @@ static inline RECreditCardType RECreditCardTypeFromNumber(NSString *creditCardNu
                 self.cvvField.frame = CGRectMake(CGRectGetMaxX(self.expirationDateField.frame), self.cvvField.frame.origin.y, self.cvvField.frame.size.width, self.cvvField.frame.size.height);
             }];
         }
-
+        
         if (textField.text.length == (isAmex ? 17 : 18) ) {
             [UIView animateWithDuration:0.1 animations:^{
                 self.isNumberEditingMode = YES;
@@ -362,15 +362,15 @@ static inline RECreditCardType RECreditCardTypeFromNumber(NSString *creditCardNu
             }];
         }
     }
-
+    
     if (textField.tag == 1) {
         self.item.expirationDate = textField.text;
-
+        
         if(textField.text.length == 5 && self.item.cvvRequired) {
             [self.cvvField becomeFirstResponder];
         }
     }
-
+    
     if (textField.tag == 2) self.item.cvv = textField.text;
 }
 
@@ -386,14 +386,14 @@ static inline RECreditCardType RECreditCardTypeFromNumber(NSString *creditCardNu
     if (textField.tag == 2) {
         [UIView transitionFromView:self.currentImageView toView:self.creditCardBackImageView duration:0.4 options:UIViewAnimationOptionTransitionFlipFromLeft completion:nil];
     }
-
+    
     return YES;
 }
 
 - (BOOL)textFieldShouldEndEditing:(UITextField *)textField
 {
     [self performSelector:@selector(flipCreditCardImageViewBack:) withObject:textField afterDelay:0.1];
-
+    
     if (textField == self.expirationDateField) {
         self.ribbonExpired.hidden = !RECreditCardExpired(self.expirationDateField.text);
     }

--- a/RETableViewManager/Items/RECreditCardItem.m
+++ b/RETableViewManager/Items/RECreditCardItem.m
@@ -24,6 +24,7 @@
 //
 
 #import "RECreditCardItem.h"
+#import "NSBundle+RETableViewManager.h"
 
 @implementation RECreditCardItem
 
@@ -49,19 +50,19 @@
     self = [super init];
     if (!self)
         return nil;
-    
+
     self.number = number;
     self.expirationDate = expirationDate;
     self.cvv = cvv;
     self.cvvRequired = YES;
-    
+
     return self;
 }
 
 - (UIImage *)expiredRibbonImage
 {
     if (!_expiredRibbonImage) {
-        _expiredRibbonImage = [UIImage imageNamed:@"RETableViewManager.bundle/Ribbon_Expired"];
+        _expiredRibbonImage = [UIImage imageNamed:@"Ribbon_Expired" inBundle:[NSBundle RETableViewManagerBundle] compatibleWithTraitCollection:nil];
     }
     return _expiredRibbonImage;
 }

--- a/RETableViewManager/Items/RECreditCardItem.m
+++ b/RETableViewManager/Items/RECreditCardItem.m
@@ -50,12 +50,12 @@
     self = [super init];
     if (!self)
         return nil;
-
+    
     self.number = number;
     self.expirationDate = expirationDate;
     self.cvv = cvv;
     self.cvvRequired = YES;
-
+    
     return self;
 }
 

--- a/RETableViewManager/NSBundle+RETableViewManager.h
+++ b/RETableViewManager/NSBundle+RETableViewManager.h
@@ -1,0 +1,15 @@
+//
+//  RETableViewManagerBundle.h
+//  Pods
+//
+//  Created by Kel Bucey on 3/3/16.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSBundle (RETableViewManager)
+
++ (instancetype)RETableViewManagerBundle;
+
+@end

--- a/RETableViewManager/NSBundle+RETableViewManager.m
+++ b/RETableViewManager/NSBundle+RETableViewManager.m
@@ -1,0 +1,28 @@
+//
+//  RETableViewManagerBundle.m
+//  Pods
+//
+//  Created by Kel Bucey on 3/3/16.
+//
+//
+
+#import "NSBundle+RETableViewManager.h"
+#import "RETableViewManager.h"
+
+@implementation NSBundle (RETableViewManager)
+
++ (instancetype)RETableViewManagerBundle {
+    static NSBundle *bundle = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSBundle *containingBundle = [NSBundle bundleForClass:[RETableViewManager class]];
+        NSURL *bundleURL = [containingBundle URLForResource:@"RETableViewManager" withExtension:@"bundle"];
+        if (bundleURL) {
+            bundle = [NSBundle bundleWithURL:bundleURL];
+        }
+    });
+    
+    return bundle;
+}
+
+@end

--- a/RETableViewManager/REActionBar.m
+++ b/RETableViewManager/REActionBar.m
@@ -25,6 +25,7 @@
 
 #import "REActionBar.h"
 #import "RETableViewManager.h"
+#import "NSBundle+RETableViewManager.h"
 
 @interface REActionBar ()
 
@@ -39,33 +40,33 @@
     self = [super init];
     if (!self)
         return nil;
-    
+
     [self sizeToFit];
-    
+
     UIBarButtonItem *doneButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(handleActionBarDone:)];
-    
+
     self.navigationControl = [[UISegmentedControl alloc] initWithItems:[NSArray arrayWithObjects:NSLocalizedString(@"Previous", @""), NSLocalizedString(@"Next", @""), nil]];
     self.navigationControl.momentary = YES;
     [self.navigationControl addTarget:self action:@selector(handleActionBarPreviousNext:) forControlEvents:UIControlEventValueChanged];
-    
-    [self.navigationControl setImage:[UIImage imageNamed:@"RETableViewManager.bundle/UIButtonBarArrowLeft"] forSegmentAtIndex:0];
-    [self.navigationControl setImage:[UIImage imageNamed:@"RETableViewManager.bundle/UIButtonBarArrowRight"] forSegmentAtIndex:1];
-    
+
+    [self.navigationControl setImage:[UIImage imageNamed:@"UIButtonBarArrowLeft" inBundle:[NSBundle RETableViewManagerBundle] compatibleWithTraitCollection:nil] forSegmentAtIndex:0];
+    [self.navigationControl setImage:[UIImage imageNamed:@"UIButtonBarArrowRight" inBundle:[NSBundle RETableViewManagerBundle] compatibleWithTraitCollection:nil] forSegmentAtIndex:1];
+
     [self.navigationControl setDividerImage:[[UIImage alloc] init]
                         forLeftSegmentState:UIControlStateNormal
                           rightSegmentState:UIControlStateNormal
                                  barMetrics:UIBarMetricsDefault];
-    
-    [self.navigationControl setBackgroundImage:[UIImage imageNamed:@"RETableViewManager.bundle/Transparent"] forState:UIControlStateNormal barMetrics:UIBarMetricsDefault];
+
+    [self.navigationControl setBackgroundImage:[UIImage imageNamed:@"Transparent" inBundle:[NSBundle RETableViewManagerBundle] compatibleWithTraitCollection:nil] forState:UIControlStateNormal barMetrics:UIBarMetricsDefault];
     [self.navigationControl setWidth:40.0f forSegmentAtIndex:0];
     [self.navigationControl setWidth:40.0f forSegmentAtIndex:1];
     [self.navigationControl setContentOffset:CGSizeMake(-4, 0) forSegmentAtIndex:0];
-    
+
     UIBarButtonItem *prevNextWrapper = [[UIBarButtonItem alloc] initWithCustomView:self.navigationControl];
     UIBarButtonItem *flexible = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];
     [self setItems:[NSArray arrayWithObjects:prevNextWrapper, flexible, doneButton, nil]];
     self.actionBarDelegate = delegate;
-    
+
     return self;
 }
 

--- a/RETableViewManager/REActionBar.m
+++ b/RETableViewManager/REActionBar.m
@@ -40,33 +40,33 @@
     self = [super init];
     if (!self)
         return nil;
-
+    
     [self sizeToFit];
-
+    
     UIBarButtonItem *doneButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(handleActionBarDone:)];
-
+    
     self.navigationControl = [[UISegmentedControl alloc] initWithItems:[NSArray arrayWithObjects:NSLocalizedString(@"Previous", @""), NSLocalizedString(@"Next", @""), nil]];
     self.navigationControl.momentary = YES;
     [self.navigationControl addTarget:self action:@selector(handleActionBarPreviousNext:) forControlEvents:UIControlEventValueChanged];
-
+    
     [self.navigationControl setImage:[UIImage imageNamed:@"UIButtonBarArrowLeft" inBundle:[NSBundle RETableViewManagerBundle] compatibleWithTraitCollection:nil] forSegmentAtIndex:0];
     [self.navigationControl setImage:[UIImage imageNamed:@"UIButtonBarArrowRight" inBundle:[NSBundle RETableViewManagerBundle] compatibleWithTraitCollection:nil] forSegmentAtIndex:1];
-
+    
     [self.navigationControl setDividerImage:[[UIImage alloc] init]
                         forLeftSegmentState:UIControlStateNormal
                           rightSegmentState:UIControlStateNormal
                                  barMetrics:UIBarMetricsDefault];
-
+    
     [self.navigationControl setBackgroundImage:[UIImage imageNamed:@"Transparent" inBundle:[NSBundle RETableViewManagerBundle] compatibleWithTraitCollection:nil] forState:UIControlStateNormal barMetrics:UIBarMetricsDefault];
     [self.navigationControl setWidth:40.0f forSegmentAtIndex:0];
     [self.navigationControl setWidth:40.0f forSegmentAtIndex:1];
     [self.navigationControl setContentOffset:CGSizeMake(-4, 0) forSegmentAtIndex:0];
-
+    
     UIBarButtonItem *prevNextWrapper = [[UIBarButtonItem alloc] initWithCustomView:self.navigationControl];
     UIBarButtonItem *flexible = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];
     [self setItems:[NSArray arrayWithObjects:prevNextWrapper, flexible, doneButton, nil]];
     self.actionBarDelegate = delegate;
-
+    
     return self;
 }
 


### PR DESCRIPTION
When the option 'use_frameworks!' is used in CocoaPods, resources where not being loaded properly. This pull request fixes this issue and loads the resources from the proper bundle.